### PR TITLE
Don't load any services until the protokube image has been fetched

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -63,15 +63,23 @@ var _ fi.HasName = &Service{}
 
 func (p *Service) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	var deps []fi.Task
-	for _, v := range tasks {
+	for name, v := range tasks {
 		// We assume that services depend on everything except for
 		// LoadImageTask. If there are any LoadImageTasks (e.g. we're
 		// launching a custom Kubernetes build), they all depend on
 		// the "docker.service" Service task.
+		// However, if protokube is being loaded using a LoadImageTask
+		// we run that first, before any other service
 		switch v.(type) {
 		case *File, *Package, *UpdatePackages, *UserTask, *GroupTask, *MountDiskTask, *Chattr:
 			deps = append(deps, v)
-		case *Service, *LoadImageTask:
+		case *LoadImageTask:
+			// Since basically nothing works without the protokube image
+			// do that first, right after restarting docker
+			if p.Name != "docker.service" && name == "LoadImage.protokube" {
+				deps = append(deps, v)
+			}
+		case *Service:
 			// ignore
 		default:
 			glog.Warningf("Unhandled type %T in Service::GetDependencies: %v", v, v)


### PR DESCRIPTION
The previous PR is actually unsound, as kops was _relying_ on node-authorizer failing in order to trigger the load of the protokube image. It was only working in production because our AMI has protokube preloaded. For some reason, kops attempts to load protokube and other services that depend on it, waits for them to all either launch or fail, and _then_ tries to load the protokube image. This PR changes the dependencies so that if protokube needs to be loaded, it is done before any services (other than docker) launch.