### PR TITLE
Improve node bootstrap time with node-authorizer and protokube in s3

### DIFF
--- a/nodeup/pkg/model/node_authorizer.go
+++ b/nodeup/pkg/model/node_authorizer.go
@@ -97,8 +97,10 @@ func (b *NodeAuthorizationBuilder) Build(c *fi.ModelBuilderContext) error {
 			timeout = na.Timeout.Duration
 		}
 
+		// TODO: Simplfy once https://github.com/systemd/systemd/pull/13754 is available
 		// @node: using a string array just to make it easier to read
 		dockerCmd := []string{
+			"/bin/bash -c 'until",
 			"/usr/bin/docker",
 			"run",
 			"--rm",
@@ -116,7 +118,9 @@ func (b *NodeAuthorizationBuilder) Build(c *fi.ModelBuilderContext) error {
 			"--tls-client-ca=/config/ca.pem",
 			"--tls-cert=/config/tls.pem",
 			"--tls-private-key=/config/tls-key.pem",
+			"; do echo node-authorizer failed, restarting in 2 seconds; sleep 2; done'",
 		}
+
 		man.Set("Service", "ExecStart", strings.Join(dockerCmd, " "))
 
 		// @step: add the service task


### PR DESCRIPTION
When using `node-authorizer` and a protokube image that must be pulled via http, node bootstrap takes more than 5 minutes because the order of dependencies is screwed up. What happens is:

- kops starts protokube, node-authorizer, and kubelet at the same time
- protokube cannot start until the protokube image is pulled, node-authorizer fails because protokube has not added the master ips to `/etc/hosts`, and kubelet fails because node-authorizer hasn't completed its task
- After a minute or two, kops notices the failure, finally starts the `LoadImage.protokube` task that loads protokube, and restarts node-authorizer
- node-authorizer fails again because protokube is still being pulled
- protokube is pulled and is started
- node-authorizer, after another minute or two, is restarted again by kops and succeeds
- kubelet finally succeeds and the node joins the cluster

With this patch:

- The protokube image is loaded first, before the protokube, node-authorizer, or kubelet services are
- node-authorizer continuously retries until it succeeds

Node bootstrap now takes ~2 minutes.

I have tested this patch, and it works at least in our setup, but I don't know if this is unsound in other configurations. In particular, I noticed that kops seemed to *depend* on node-authorizer either failing or succeeding to make progress. If we didn't load the protokube image *before* starting node-authorizer, kops would hang indefinitely and never bootstrap.